### PR TITLE
Handle constant closing prices

### DIFF
--- a/src/main/java/com/example/smartstockanalysis/utils/DataPreprocessingUtils.java
+++ b/src/main/java/com/example/smartstockanalysis/utils/DataPreprocessingUtils.java
@@ -25,6 +25,14 @@ public class DataPreprocessingUtils {
         double max = closingPrices.stream().max(Double::compareTo).orElse(1.0);
 
         List<Double> normalized = new ArrayList<>();
+
+        // Se tutti i valori sono uguali, restituisce una lista di zeri
+        if (Double.compare(max, min) == 0) {
+            for (int i = 0; i < closingPrices.size(); i++) {
+                normalized.add(0.0);
+            }
+            return normalized;
+        }
         for (double value : closingPrices) {
             double norm = (value - min) / (max - min);
             normalized.add(norm);

--- a/src/test/java/com/example/smartstockanalysis/DataPreprocessingUtilsTest.java
+++ b/src/test/java/com/example/smartstockanalysis/DataPreprocessingUtilsTest.java
@@ -1,0 +1,46 @@
+package com.example.smartstockanalysis;
+
+import com.example.smartstockanalysis.model.StockData;
+import com.example.smartstockanalysis.utils.DataPreprocessingUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataPreprocessingUtilsTest {
+
+    @Test
+    void testExtractNormalizedClosingPrices() {
+        List<StockData> data = Arrays.asList(
+                new StockData(new Date(), 0, 0, 0, 10.0, 0),
+                new StockData(new Date(), 0, 0, 0, 20.0, 0),
+                new StockData(new Date(), 0, 0, 0, 30.0, 0)
+        );
+
+        List<Double> normalized = DataPreprocessingUtils.extractNormalizedClosingPrices(data);
+
+        assertEquals(3, normalized.size());
+        assertEquals(0.0, normalized.get(0));
+        assertEquals(0.5, normalized.get(1));
+        assertEquals(1.0, normalized.get(2));
+    }
+
+    @Test
+    void testExtractNormalizedClosingPricesConstantValues() {
+        List<StockData> data = Arrays.asList(
+                new StockData(new Date(), 0, 0, 0, 10.0, 0),
+                new StockData(new Date(), 0, 0, 0, 10.0, 0),
+                new StockData(new Date(), 0, 0, 0, 10.0, 0)
+        );
+
+        List<Double> normalized = DataPreprocessingUtils.extractNormalizedClosingPrices(data);
+
+        assertEquals(3, normalized.size());
+        assertEquals(0.0, normalized.get(0));
+        assertEquals(0.0, normalized.get(1));
+        assertEquals(0.0, normalized.get(2));
+    }
+}


### PR DESCRIPTION
## Summary
- avoid divide-by-zero when normalizing constant closing prices
- test DataPreprocessingUtils on normal data
- test DataPreprocessingUtils on constant-price data

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e9d99e9c8326bf3a4b0150252d8c