### PR TITLE
Fix Yahoo Finance endpoint path

### DIFF
--- a/src/main/java/com/example/smartstockanalysis/controller/StockAnalysisController.java
+++ b/src/main/java/com/example/smartstockanalysis/controller/StockAnalysisController.java
@@ -34,8 +34,8 @@ public class StockAnalysisController {
     private SpringAiService springAiService;
 
 
-    @GetMapping("/predict/yahoofinace")
-    public PredictionResult predictYahooFinace(@RequestParam String ticker) {
+    @GetMapping("/predict/yahoofinance")
+    public PredictionResult predictYahooFinance(@RequestParam String ticker) {
         List<StockData> stockData = yahooFinanceService.getStockData(ticker);
         List<Double> normalized = yahooFinanceService.preprocessStockData(stockData);
 


### PR DESCRIPTION
## Summary
- correct path typo from `/predict/yahoofinace` to `/predict/yahoofinance`
- rename controller method accordingly

## Testing
- `mvn -q test` *(fails: command not found)*
