### PR TITLE
Add Dockerfile for running tests

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,9 @@
+FROM maven:3.9-eclipse-temurin-17
+
+WORKDIR /app
+
+COPY pom.xml ./
+COPY .mvn/ .mvn
+COPY src/ ./src
+
+CMD ["mvn", "test"]


### PR DESCRIPTION
## Summary
- add a Dockerfile (`Dockerfile.test`) that runs `mvn test` by default

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*
