### PR TITLE
Fix dataset path usage

### DIFF
--- a/src/main/java/com/example/smartstockanalysis/utils/DatasetUtils.java
+++ b/src/main/java/com/example/smartstockanalysis/utils/DatasetUtils.java
@@ -19,7 +19,7 @@ public class DatasetUtils {
                 datasetDir.mkdirs();
             }
 
-            FileWriter writer = new FileWriter("datasets/training_data.csv", true);
+            FileWriter writer = new FileWriter(DATASET_PATH, true);
             StringBuilder line = new StringBuilder();
 
             for (Double feature : features) {


### PR DESCRIPTION
## Summary
- use the `DATASET_PATH` constant when writing the training CSV so it is defined in one place

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

